### PR TITLE
Upgrade to Bootstrap 5, drop jQuery/Tether, Font Awesome 6

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -149,12 +149,6 @@ section {
 /*----------------------------------------------
 * Navigation
 ----------------------------------------------*/
-@media (max-width: 992px) {
-    .navbar-toggleable-md .navbar-collapse {
-        display: flex !important;
-    }
-}
-
 .navbar{
     min-height: 70px;
 }
@@ -214,16 +208,6 @@ section {
 }
 .navbar-toggler:focus{
     outline: none;
-}
-.dropdown-toggle::after {
-    vertical-align: top;
-    content: "\f3d0";
-    border-top: none;
-    border-right: none;
-    border-left: none;
-    font-family: "Ionicons";
-    font-size: 17px;
-    margin-top: -4px;
 }
 .navbar-nav .dropdown .dropdown-toggle:after {
     margin-top: 0px;

--- a/index.html
+++ b/index.html
@@ -5,8 +5,8 @@
         <title>Marti</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <link rel="icon" type="image/x-icon" href="img/favicon.ico" />
-        <!--Bootstrap 4-->
-        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
+        <!--Bootstrap 5-->
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" crossorigin="anonymous">
         <!--custom css-->
         <link rel="stylesheet" href="css/components.css" />
         <link rel="stylesheet" href="css/colors.css" />
@@ -28,10 +28,10 @@
                                     An engineer
                                 </h6>
 
-                                <a href="cv/cv_LUjiyan.pdf" target="_blank" class="btn btn-white btn-round mr-3">
+                                <a href="cv/cv_LUjiyan.pdf" target="_blank" class="btn btn-white btn-round me-3">
                                     CV
                                 </a>
-                                <a href="space/" class="btn btn-white btn-round mr-3">
+                                <a href="space/" class="btn btn-white btn-round me-3">
                                     Space
                                 </a>
 

--- a/space/index.html
+++ b/space/index.html
@@ -5,10 +5,10 @@
         <title>Marti</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <link rel="icon" type="image/x-icon" href="../img/favicon.ico" />
-        <!--Bootstrap 4-->
-        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
+        <!--Bootstrap 5-->
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" crossorigin="anonymous">
         <!--icons-->
-        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.7.2/css/all.min.css">
         <!--custom css-->
         <link rel="stylesheet" href="../css/components.css" />
         <link rel="stylesheet" href="../css/colors.css" />
@@ -16,15 +16,11 @@
     <body>
 
         <!--header-->
-        <nav class="navbar navbar-toggleable-md fixed-top navbar-transparent sticky-navigation-alt">
-            <!-- <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
-                <span class="ion-grid"></span>
-            </button> -->
-
+        <nav class="navbar navbar-expand fixed-top navbar-transparent">
             <div class="collapse navbar-collapse" id="navbarCollapse">
-                <ul class="navbar-nav ml-auto">
+                <ul class="navbar-nav ms-auto">
                     <li class="nav-item dropdown">
-                        <a class="nav-link dropdown-toggle" href="#" id="nav-reads" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        <a class="nav-link dropdown-toggle" href="#" id="nav-reads" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                             Reads
                         </a>
                         <div class="dropdown-menu" aria-labelledby="nav-reads">
@@ -54,10 +50,10 @@
                     </li>
 
                     <li class="nav-item">
-                        <a class="nav-link" data-toggle="tooltip" data-placement="bottom" data-title="instagram" target="_blank" href="https://www.instagram.com/martibook"><em class="fa fa-instagram"></em></a>
+                        <a class="nav-link" title="instagram" target="_blank" href="https://www.instagram.com/martibook"><em class="fa-brands fa-instagram"></em></a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" data-toggle="tooltip" data-placement="bottom" data-title="github" target="_blank" href="https://github.com/martibook"><em class="fa fa-github"></em></a>
+                        <a class="nav-link" title="github" target="_blank" href="https://github.com/martibook"><em class="fa-brands fa-github"></em></a>
                     </li>
                 </ul>
             </div>
@@ -85,7 +81,7 @@
             </section>
 
             <!--footer-->
-            <section class="colored-section bg-inverse">
+            <section class="colored-section bg-dark">
                 <div class="container">
                     <div class="row">
                         <div class="col-md-8 offset-md-2 text-center">
@@ -99,10 +95,8 @@
             </section>
         </div>
 
-        <!--Bootstrap dropdown deps (jQuery + Tether required by Bootstrap 4 alpha JS)-->
-        <script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.4.0/js/tether.min.js"></script>
-        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/js/bootstrap.min.js"></script>
+        <!--Bootstrap 5 bundle (Popper included; no jQuery needed)-->
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"></script>
         <script>
             function hideBrand() {
                 var e = document.getElementById("brand");


### PR DESCRIPTION
Bold stack upgrade: moves the site off the unmaintained **Bootstrap 4.0.0-alpha.6** (a 2017 pre-release), **jQuery 3.1.1**, and the deprecated **Tether** to a current, supported set — all served from **jsDelivr** instead of the legacy `maxcdn.bootstrapcdn.com`.

## Dependency changes
| Was | Now |
|---|---|
| Bootstrap `4.0.0-alpha.6` (maxcdn) | Bootstrap `5.3.8` CSS + `bootstrap.bundle.min.js` (Popper included) |
| jQuery `3.1.1` | **removed** (had known XSS/prototype-pollution CVEs) |
| Tether `1.4.0` | **removed** (deprecated; replaced by Popper in the BS5 bundle) |
| Font Awesome `4.7.0` | Font Awesome `6.7.2` (`fa-brands` for social icons) |

The Space page dropdown now runs on Bootstrap 5s own JS — **no jQuery**. The `showReads` script was already vanilla DOM, so nothing else depended on it. The home page has no JS at all.

## Markup updates for BS5
- `navbar-toggleable-md` → `navbar-expand` (menu is always shown — there was no working hamburger toggler), which also let me delete a `display:flex !important` hack.
- `data-toggle` → `data-bs-toggle`, `ml-auto` → `ms-auto`, `mr-3` → `me-3`, `bg-inverse` → `bg-dark`, `role="button"` on the dropdown toggle.
- Replaced the never-initialised `data-toggle="tooltip"` attributes with native `title=""` tooltips — zero JS and they actually work now.
- Removed the dead commented hamburger button (it referenced the already-deleted `ion-grid` glyph).

## CSS cleanup
- Dropped the Ionicons-based `.dropdown-toggle::after` caret override. Ionicons was removed in an earlier PR, so that caret was rendering as a tofu box; Bootstrap 5s native triangle caret now shows.
- Removed the now-redundant navbar-collapse display hack.

## Verification (headless, Puppeteer)
✅ Bootstrap 5 loads &nbsp;✅ jQuery absent &nbsp;✅ Reads dropdown opens &nbsp;✅ caret renders &nbsp;✅ FA6 social icons render &nbsp;✅ clicking a read fetches + displays the text and hides the brand &nbsp;✅ both pages load with **no console errors / no failed requests**.

Net: **−22 lines**, three external libraries removed, and off the legacy CDN. Follow-up candidates from the review: dedupe the shared `<head>`, data-driven Reads menu, and merging `showReads`/`showReadsEachLine`.