### PR TITLE
Auto-link Recent Activity to my latest pushed repo

### DIFF
--- a/space/index.html
+++ b/space/index.html
@@ -60,7 +60,7 @@
                             <div id="brand" class="brand">
                                 <h1 class="text-white">What's Going On</h1>
                                 <h5 class="text-uppercase mb-5"></h5>
-                                <a href="https://github.com/martibook/double-select" target="_blank" class="btn btn-outline-white btn-round page-scroll">
+                                <a id="recent-activity" href="https://github.com/martibook/wm" target="_blank" class="btn btn-outline-white btn-round page-scroll">
                                     Recent Activity
                                 </a>
                             </div>
@@ -105,6 +105,20 @@
                 document.getElementById("reads").style.display = "block";
                 document.getElementById("read-" + slug).style.display = "block";
             }
+
+            // Point "Recent Activity" at my most recently pushed repo (excluding this site).
+            // Falls back to the hardcoded href if the API call fails.
+            fetch("https://api.github.com/users/martibook/repos?sort=pushed&per_page=10&type=owner")
+                .then(function (res) { return res.ok ? res.json() : Promise.reject(res.status); })
+                .then(function (repos) {
+                    var latest = repos.find(function (r) {
+                        return !r.fork && r.name !== "martibook.github.io";
+                    });
+                    if (latest) {
+                        document.getElementById("recent-activity").href = latest.html_url;
+                    }
+                })
+                .catch(function () { /* keep the fallback href */ });
         </script>
     </body>
 </html>


### PR DESCRIPTION
## What
Makes the **Recent Activity** button on the Space page always point at my most recently pushed repo instead of a hardcoded one.

- Replaces the static `martibook/double-select` link with a small client-side GitHub API fetch (`/users/martibook/repos?sort=pushed`).
- Picks the most recently pushed **owned** repo, excluding this site (`martibook.github.io`) and forks.
- Falls back to a hardcoded href (`martibook/wm`) if the API call fails or rate-limits, so the button always works.

## Why
Keeps the link current automatically — no manual edits each time I push to a new project.

## Verification
Confirmed the unauthenticated public API (what a visitor's browser hits) resolves to `martibook/wm` as the top non-fork, non-site repo, and previewed the rendered page locally.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
